### PR TITLE
Adding the ability to setContentLabels

### DIFF
--- a/src/Confluence.coffee
+++ b/src/Confluence.coffee
@@ -28,6 +28,9 @@ class Confluence
 
   getContentLabels:(contentId, params, callback) ->
     @XHR "GET", "/content/#{contentId}/label", params, null, callback
+    
+  setContentLabels:(contentId, payload, callback) ->
+    @XHR "POST", "/content/#{contentId}/label", null, payload, callback
 
   getContentChildren:(contentId, params, callback) ->
     @XHR "GET", "/content/#{contentId}/child", params, null, callback


### PR DESCRIPTION
The project I was working on required the ability to set the labels of the page content I was creating so I added the setContentLabels method.

Sample usage:

``` javascript
var confluence = require('atlassian-confluence');
var contentId = 12345; // your page id
var labels = [{ prefix: "global", name: "mylabel"];
confluence.setContentLabels(contentId, labels, function (labels) {
    // Do stuff
});
```
