### PR TITLE
Bugfix : specify correct byte length for multibyte payload.

### DIFF
--- a/src/Confluence.coffee
+++ b/src/Confluence.coffee
@@ -116,7 +116,7 @@ class Confluence
       auth: "#{@username}:#{@password}"
       headers:
         'Content-Type': 'application/json'
-        'Content-Length': payloadString.length
+        'Content-Length': Buffer.byteLength(payloadString)
 
     req = http.request options, (res) ->
       res.setEncoding 'utf8'


### PR DESCRIPTION
I encountered a error when use multibyte characters.

Currently, `Content-Length` just use string length.
So I fixed to use byte length.